### PR TITLE
Fix video download errors across platforms

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,10 @@
 fastapi==0.111.0
 uvicorn[standard]==0.30.1
-yt-dlp>=2024.08.06
+# Pin to recent yt-dlp to catch latest extractors
+yt-dlp>=2025.01.10
 aiofiles==23.2.1
-httpx==0.28.1
+# Enable HTTP/2
+httpx[http2]==0.28.1
+# Brotli decoding (some CDNs compress segments aggressively)
+brotli==1.1.0
+curl_cffi==0.7.1


### PR DESCRIPTION
Enhance download robustness for YouTube, Facebook, and TikTok by updating `yt-dlp`, improving proxy headers, and adding an anti-bot fallback.

This PR addresses common download failures across platforms: YouTube and Facebook issues are largely resolved by upgrading `yt-dlp` and improving header propagation. TikTok's anti-bot measures are tackled with HTTP/2 support and a `curl_cffi` Chrome-impersonation fallback, which helps bypass 403/4xx errors from CDNs. Cookie handling and IPv4 preference also contribute to overall stability.

---
<a href="https://cursor.com/background-agent?bcId=bc-b80c592a-30f1-464b-a97a-52664fc7886e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b80c592a-30f1-464b-a97a-52664fc7886e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

