### PR TITLE
Find and fix a bug in important code

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -396,7 +396,11 @@ async def proxy_download(request: Request, source: str, format_id: str):
                         if not getattr(c, "domain", None):
                             continue
                         dom = c.domain.lstrip(".")
-                        if host.endswith(dom):
+                        # Fix: Proper domain matching to prevent subdomain attacks
+                        # The host must either match the domain exactly or be a subdomain of it
+                        # by ensuring there's a dot before the domain part
+                        # Also prevent matching single-label domains (TLDs) for security
+                        if dom and host and "." in dom and (host == dom or host.endswith("." + dom)):
                             cookie_pairs.append(f"{c.name}={c.value}")
                     if cookie_pairs:
                         headers.setdefault("Cookie", "; ".join(cookie_pairs))

--- a/server/tests/test_cookie_domain_matching.py
+++ b/server/tests/test_cookie_domain_matching.py
@@ -1,0 +1,90 @@
+"""
+Test for cookie domain matching security fix.
+
+This test verifies that the cookie domain matching logic correctly handles
+domain matching to prevent security vulnerabilities where cookies could be
+sent to unintended domains.
+"""
+
+import unittest
+from unittest.mock import Mock, MagicMock, patch
+from http.cookiejar import Cookie
+
+
+class TestCookieDomainMatching(unittest.TestCase):
+    """Test cookie domain matching logic to prevent security vulnerabilities."""
+
+    def test_cookie_domain_matching_security(self):
+        """Test that cookie domain matching prevents subdomain attacks."""
+        
+        # Test cases: (host, cookie_domain, should_match)
+        test_cases = [
+            # Exact domain match - should match
+            ("example.com", "example.com", True),
+            ("example.com", ".example.com", True),
+            
+            # Valid subdomain - should match
+            ("www.example.com", "example.com", True),
+            ("www.example.com", ".example.com", True),
+            ("api.example.com", "example.com", True),
+            ("api.example.com", ".example.com", True),
+            ("sub.sub.example.com", "example.com", True),
+            
+            # Invalid matches - security vulnerability if these match
+            ("notevil.com", "evil.com", False),  # Critical: prevent suffix matching
+            ("notevil.com", ".evil.com", False),
+            ("example.com", "ample.com", False),  # Suffix is not subdomain
+            ("myexample.com", "example.com", False),
+            ("myexample.com", ".example.com", False),
+            
+            # Different domains - should not match
+            ("example.org", "example.com", False),
+            ("example.org", ".example.com", False),
+            ("google.com", "example.com", False),
+            
+            # Edge cases - prevent TLD-only matching
+            ("com", ".com", False),  # TLD shouldn't match - security issue
+            ("example.com", ".com", False),  # .com cookie shouldn't match all .com domains
+            ("", "example.com", False),  # Empty host
+            ("example.com", "", False),  # Empty domain
+        ]
+        
+        for host, cookie_domain, should_match in test_cases:
+            with self.subTest(host=host, cookie_domain=cookie_domain):
+                # Simulate the fixed logic from main.py
+                dom = cookie_domain.lstrip(".")
+                
+                # This is the FIXED logic with TLD protection
+                matches = bool(dom and host and "." in dom and (host == dom or host.endswith("." + dom)))
+                
+                # Verify against expected result
+                self.assertEqual(
+                    matches, 
+                    should_match,
+                    f"Domain matching failed for host='{host}', domain='{cookie_domain}'. "
+                    f"Expected {'match' if should_match else 'no match'}, got {'match' if matches else 'no match'}"
+                )
+    
+    def test_vulnerable_cookie_domain_matching(self):
+        """Demonstrate the vulnerability in the OLD cookie matching logic."""
+        
+        # This test shows why the old logic was vulnerable
+        host = "notevil.com"
+        cookie_domain = "evil.com"
+        
+        # OLD vulnerable logic (what we fixed)
+        dom = cookie_domain.lstrip(".")
+        vulnerable_match = host.endswith(dom)  # This would incorrectly return True!
+        
+        # The vulnerable logic would match - this is BAD
+        self.assertTrue(vulnerable_match, "Old logic has vulnerability - 'notevil.com' matches 'evil.com'")
+        
+        # NEW fixed logic with TLD protection
+        fixed_match = bool(dom and host and "." in dom and (host == dom or host.endswith("." + dom)))
+        
+        # The fixed logic correctly does NOT match - this is GOOD
+        self.assertFalse(fixed_match, "Fixed logic prevents vulnerability - 'notevil.com' does not match 'evil.com'")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes a critical cookie domain matching vulnerability to prevent subdomain attacks and TLD-only cookie issues.

The previous `host.endswith(dom)` logic was vulnerable to subdomain attacks (e.g., `notevil.com` incorrectly matching `evil.com`) and allowed cookies for single-label domains (TLDs) like `.com`. This could lead to security risks such as session hijacking and privacy leaks. The updated logic enforces stricter matching, requiring an exact match or a proper subdomain with a preceding dot, and disallows single-label domains for enhanced security.

---
<a href="https://cursor.com/background-agent?bcId=bc-baf0f01d-8f7b-4c19-87fb-b76a848d4e81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-baf0f01d-8f7b-4c19-87fb-b76a848d4e81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

