### PR TITLE
Find and fix a bug in important code

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -59,7 +59,7 @@ class FormatModel(BaseModel):
     format_id: str
     ext: Optional[str] = None
     resolution: Optional[str] = None
-    fps: Optional[int] = None
+    fps: Optional[float] = None
     acodec: Optional[str] = None
     vcodec: Optional[str] = None
     filesize: Optional[int] = None

--- a/server/tests/test_utils.py
+++ b/server/tests/test_utils.py
@@ -2,7 +2,7 @@ import math
 import pytest
 
 import os
-from server.main import human_readable_bytes, build_ydl_opts
+from server.main import human_readable_bytes, build_ydl_opts, FormatModel
 
 
 @pytest.mark.parametrize(
@@ -33,3 +33,9 @@ def test_build_ydl_opts_user_agent_override_does_not_mutate_env():
     # But environment should still not contain AOI_USER_AGENT unless explicitly set
     assert os.getenv("AOI_USER_AGENT") is None
 
+
+def test_formatmodel_allows_fractional_fps():
+    # fps can be non-integer like 29.97; ensure model accepts and preserves it
+    fmt = FormatModel(format_id="test", fps=29.97)
+    assert isinstance(fmt.fps, float)
+    assert fmt.fps == 29.97


### PR DESCRIPTION
Update `FormatModel.fps` to `float` to correctly handle fractional frame rates.

The `FormatModel.fps` attribute was previously typed as `int`, which caused truncation of fractional frame rates (e.g., 29.97). Changing it to `float` ensures these values are preserved, fixing an API serialization bug. A regression test has been added to validate this behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-369bd526-4612-4a18-8bf9-aad554f5dc89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-369bd526-4612-4a18-8bf9-aad554f5dc89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

