### PR TITLE
Clean up proxy headers, align Node requirement, extend byte tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run -p 8000:8000 all-in-one-downloader
 
 ## Run locally (without Docker)
 
-Requirements: Python 3.11+, Node 18+
+Requirements: Python 3.11+, Node 20+
 
 ```bash
 # Backend

--- a/server/main.py
+++ b/server/main.py
@@ -343,7 +343,6 @@ async def proxy_download(request: Request, source: str, format_id: str):
         raise HTTPException(status_code=400, detail="Invalid source URL; must be http(s)")
 
     # Re-extract to get fresh format URL and headers, and capture cookies
-    cookie_header: Optional[str] = None
     extracted_cookiejar = None
     try:
         def _sync_extract_with_cookiejar():
@@ -374,7 +373,7 @@ async def proxy_download(request: Request, source: str, format_id: str):
 
     direct_url = target.get("url")
 
-    # Merge headers: info-level + per-format + inferred referer
+    # Merge headers: info-level + per-format + inferred referrer
     headers = (info.get("http_headers") or {}).copy()
     if target.get("http_headers"):
         headers.update(target.get("http_headers") or {})

--- a/server/tests/test_utils.py
+++ b/server/tests/test_utils.py
@@ -19,6 +19,8 @@ from ..main import human_readable_bytes, build_ydl_opts, FormatModel
         (10 * 1024 * 1024, "10.00 MB"),
         (1024 * 1024 * 1024, "1.00 GB"),
         (1024 * 1024 * 1024 * 1024, "1.00 TB"),
+        (10 * 1024 * 1024 * 1024 * 1024, "10.00 TB"),
+        (1024 * 1024 * 1024 * 1024 * 1024, "1024.00 TB"),
     ],
 )
 def test_human_readable_bytes(num, expected):


### PR DESCRIPTION
## Summary
- remove unused cookie variable and fix referrer comment in proxy download
- document Node 20+ requirement to match Dockerfile
- test byte helper beyond one terabyte

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe1d71b0883288dfc94e47d49da0b