### PR TITLE
Skip idless formats and handle larger byte units

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Beautiful, fast, and free downloader for YouTube, Facebook, TikTok, Instagram, a
 - Works for: YouTube, Facebook, TikTok, Instagram, SoundCloud (and many more supported by `yt-dlp`)
 - Single-service deploy (frontend + backend) via Docker
 
-## One‑click deploy (free)
+## One-click deploy (free)
 
 Click to deploy on Render (free tier):
 

--- a/server/tests/test_utils.py
+++ b/server/tests/test_utils.py
@@ -1,7 +1,6 @@
-import math
+import os
 import pytest
 
-import os
 from ..main import human_readable_bytes, build_ydl_opts, FormatModel
 
 
@@ -20,15 +19,17 @@ from ..main import human_readable_bytes, build_ydl_opts, FormatModel
         (1024 * 1024 * 1024, "1.00 GB"),
         (1024 * 1024 * 1024 * 1024, "1.00 TB"),
         (10 * 1024 * 1024 * 1024 * 1024, "10.00 TB"),
-        (1024 * 1024 * 1024 * 1024 * 1024, "1024.00 TB"),
+        (1024 * 1024 * 1024 * 1024 * 1024, "1.00 PB"),
+        (10 * 1024 * 1024 * 1024 * 1024 * 1024, "10.00 PB"),
+        (1024 * 1024 * 1024 * 1024 * 1024 * 1024, "1.00 EB"),
     ],
 )
 def test_human_readable_bytes(num, expected):
     assert human_readable_bytes(num) == expected
 
 
-def test_build_ydl_opts_user_agent_override_does_not_mutate_env():
-    os.environ.pop("AOI_USER_AGENT", None)
+def test_build_ydl_opts_user_agent_override_does_not_mutate_env(monkeypatch):
+    monkeypatch.delenv("AOI_USER_AGENT", raising=False)
     override = "TestAgent/1.0"
     opts = build_ydl_opts(source_url="https://example.com/video", user_agent_override=override)
     # The constructed headers should include the override UA


### PR DESCRIPTION
## Summary
- Fix README heading to use a standard hyphen
- Skip formats lacking IDs and URL-encode cookie values when constructing headers
- Support byte sizes beyond terabytes and clean up tests

## Testing
- `pytest server/tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1277e39dc8328acf21f528e7c37b5