### PR TITLE
Fix mobile view download and copy link visibility

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -678,7 +678,7 @@ function FormatRow({ format }: { format: Format }) {
   }, [format.format_id])
 
   return (
-    <div className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-slate-900/40 px-3 py-2 transition-all hover:-translate-y-0.5">
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/10 bg-slate-900/40 px-3 py-2 transition-all hover:-translate-y-0.5">
       <div className="flex items-center gap-3 min-w-0">
         <div className={clsx('h-9 w-9 grid place-items-center rounded-lg', isAudio ? 'bg-emerald-500/15' : isMuxed ? 'bg-cyan-500/15' : 'bg-purple-500/15')}>
           {isAudio ? <Music2 className="h-4 w-4 text-emerald-400"/> : isMuxed ? <PlayCircle className="h-4 w-4 text-cyan-400"/> : <Video className="h-4 w-4 text-purple-400"/>}
@@ -688,7 +688,7 @@ function FormatRow({ format }: { format: Format }) {
           <div className="text-xs text-slate-400">{format.filesize_pretty ?? 'Size unknown'}</div>
         </div>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 w-full sm:w-auto justify-end">
         {protocolLabel && (
           <span className="text-[10px] px-2 py-0.5 rounded border border-white/10 text-slate-400">{protocolLabel}</span>
         )}


### PR DESCRIPTION
Fix: Make download and copy link buttons visible on mobile by adjusting `FormatRow` layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-57667ff7-5942-43a7-b357-d4bd881badfc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57667ff7-5942-43a7-b357-d4bd881badfc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

