### PR TITLE
Improve modal focus management and download affordances

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -23,7 +23,6 @@ describe('App', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     localStorage.clear()
     sessionStorage.clear()
-    ;(window as any).__aoi_last_source = undefined
   })
 
   afterEach(() => {

--- a/web/src/components/AuthModal.tsx
+++ b/web/src/components/AuthModal.tsx
@@ -34,6 +34,10 @@ export default function AuthModal({ open, onClose, onAuthSuccess }: Props) {
   const [password, setPassword] = React.useState('')
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
+  const dialogRef = React.useRef<HTMLDivElement>(null)
+  const contentRef = React.useRef<HTMLDivElement>(null)
+  const firstFieldRef = React.useRef<HTMLInputElement>(null)
+  const lastFocusedElementRef = React.useRef<HTMLElement | null>(null)
 
   React.useEffect(() => {
     if (!open) {
@@ -44,7 +48,66 @@ export default function AuthModal({ open, onClose, onAuthSuccess }: Props) {
     }
   }, [open])
 
+  React.useEffect(() => {
+    if (open) {
+      lastFocusedElementRef.current = document.activeElement as HTMLElement | null
+      const id = requestAnimationFrame(() => {
+        if (firstFieldRef.current) {
+          firstFieldRef.current.focus()
+        } else {
+          dialogRef.current?.focus()
+        }
+      })
+      return () => cancelAnimationFrame(id)
+    }
+    const previouslyFocused = lastFocusedElementRef.current
+    if (previouslyFocused) {
+      const id = requestAnimationFrame(() => previouslyFocused.focus())
+      return () => cancelAnimationFrame(id)
+    }
+  }, [open])
+
   if (!open) return null
+
+  function onDialogKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key === 'Escape' && !e.defaultPrevented) {
+      e.preventDefault()
+      onClose()
+    }
+    if (e.key === 'Tab') {
+      const container = contentRef.current
+      if (!container) return
+      const focusable = Array.from(
+        container.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter((el) =>
+        !el.hasAttribute('disabled') &&
+        el.getAttribute('aria-hidden') !== 'true' &&
+        !el.closest('[aria-hidden="true"]')
+      )
+
+      if (focusable.length === 0) {
+        e.preventDefault()
+        dialogRef.current?.focus()
+        return
+      }
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const activeEl = document.activeElement as HTMLElement | null
+
+      if (e.shiftKey) {
+        if (!activeEl || activeEl === first || !container.contains(activeEl)) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else if (!activeEl || activeEl === last || !container.contains(activeEl)) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -79,16 +142,27 @@ export default function AuthModal({ open, onClose, onAuthSuccess }: Props) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 grid place-items-center">
-      <div className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm" onClick={onClose} />
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 z-50 grid place-items-center overflow-y-auto p-4 sm:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="auth-modal-title"
+      tabIndex={-1}
+      onKeyDown={onDialogKeyDown}
+    >
+      <div className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
 
       {/* Decorative circles */}
-      <div className="pointer-events-none absolute -top-16 -left-10 h-48 w-48 rounded-full blur-3xl bg-gradient-to-br from-fuchsia-500/30 via-purple-500/30 to-cyan-400/30" />
-      <div className="pointer-events-none absolute -bottom-16 -right-10 h-48 w-48 rounded-full blur-3xl bg-gradient-to-tr from-cyan-400/30 via-purple-500/30 to-fuchsia-500/30" />
+      <div className="pointer-events-none absolute -top-16 -left-10 h-48 w-48 rounded-full blur-3xl bg-gradient-to-br from-fuchsia-500/30 via-purple-500/30 to-cyan-400/30" aria-hidden="true" />
+      <div className="pointer-events-none absolute -bottom-16 -right-10 h-48 w-48 rounded-full blur-3xl bg-gradient-to-tr from-cyan-400/30 via-purple-500/30 to-fuchsia-500/30" aria-hidden="true" />
 
-      <div className="relative mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-slate-900/90 p-5 shadow-2xl">
+      <div
+        ref={contentRef}
+        className="relative mx-auto w-full max-w-md rounded-2xl border border-white/10 bg-slate-900/90 p-5 shadow-2xl max-h-full overflow-y-auto"
+      >
         <div className="text-center">
-          <div className="text-2xl font-semibold text-white">Log in or sign up</div>
+          <h2 id="auth-modal-title" className="text-2xl font-semibold text-white">Log in or sign up</h2>
           <div className="mt-2 inline-flex items-center rounded-full border border-white/10 bg-white/5 p-1 text-xs">
             <button
               className={clsx('px-3 py-1 rounded-full transition-colors', mode === 'login' ? 'bg-white/10 text-white' : 'text-slate-300 hover:text-white')}
@@ -102,8 +176,10 @@ export default function AuthModal({ open, onClose, onAuthSuccess }: Props) {
         </div>
 
         <form onSubmit={handleSubmit} className="mt-4 grid gap-3">
-          <label className="text-xs text-slate-400">Email address</label>
+          <label htmlFor="auth-email" className="text-xs text-slate-400">Email address</label>
           <input
+            ref={firstFieldRef}
+            id="auth-email"
             type="email"
             required
             autoComplete="email"
@@ -112,8 +188,9 @@ export default function AuthModal({ open, onClose, onAuthSuccess }: Props) {
             className="w-full rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-fuchsia-500/40"
             placeholder="you@example.com"
           />
-          <label className="mt-2 text-xs text-slate-400">Password</label>
+          <label htmlFor="auth-password" className="mt-2 text-xs text-slate-400">Password</label>
           <input
+            id="auth-password"
             type="password"
             required
             autoComplete={mode === 'signup' ? 'new-password' : 'current-password'}
@@ -122,7 +199,15 @@ export default function AuthModal({ open, onClose, onAuthSuccess }: Props) {
             className="w-full rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-fuchsia-500/40"
             placeholder="••••••••"
           />
-          {error && <div className="mt-2 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">{error}</div>}
+          {error && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="mt-2 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-200"
+            >
+              {error}
+            </div>
+          )}
           <button
             type="submit"
             disabled={loading}


### PR DESCRIPTION
## Summary
- ensure the authentication modal traps focus, restores the triggering focus, and marks error messages as alerts
- track the last analyzed source URL in component state so best-quality, subtitle, and MP3 links only render when usable
- add clipboard success feedback for download rows and gracefully disable subtitle links when the source URL is unavailable

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c8e16c6ae88328a9d7cbf45b3c76eb