### PR TITLE
Add tests for component utilities and download list

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,7 +17,7 @@ const PLATFORMS = [
   { key: 'soundcloud', label: 'SoundCloud', color: 'text-orange-400', icon: Music },
 ]
 
-type Format = {
+export type Format = {
   format_id: string
   ext?: string
   resolution?: string
@@ -65,7 +65,7 @@ async function extract(url: string): Promise<ExtractResponse> {
   return res.json()
 }
 
-function formatDuration(seconds?: number) {
+export function formatDuration(seconds?: number) {
   if (!seconds) return '—'
   const h = Math.floor(seconds / 3600)
   const m = Math.floor((seconds % 3600) / 60)
@@ -76,7 +76,7 @@ function formatDuration(seconds?: number) {
     .join(':')
 }
 
-function normalizeInputUrl(raw: string): string | null {
+export function normalizeInputUrl(raw: string): string | null {
   const t = raw.trim()
   if (!t) return null
   try {
@@ -817,7 +817,7 @@ export default function App() {
   )
 }
 
-function FormatRow({ format, source }: { format: Format, source: string | null }) {
+export function FormatRow({ format, source }: { format: Format, source: string | null }) {
   const quality = format.resolution ?? (format.audio_bitrate ? `${format.audio_bitrate}kbps` : '—')
   const isMuxed = format.vcodec && format.acodec && format.vcodec !== 'none' && format.acodec !== 'none'
   const isAudio = format.is_audio_only

--- a/web/src/components/App.download-list.test.tsx
+++ b/web/src/components/App.download-list.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { FormatRow, type Format } from '../App'
+
+describe('FormatRow download list rendering', () => {
+  const baseFormat: Format = {
+    format_id: '137',
+    ext: 'mp4',
+    resolution: '1080p',
+    fps: 60,
+    is_audio_only: false,
+    vcodec: 'avc1',
+    acodec: 'mp4a',
+    filesize_pretty: '20 MB',
+  }
+
+  const originalClipboard = navigator.clipboard
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: originalClipboard,
+        configurable: true,
+      })
+    } else {
+      Reflect.deleteProperty(navigator, 'clipboard')
+    }
+  })
+
+  it('renders key download details for muxed formats', () => {
+    render(<FormatRow format={baseFormat} source="https://example.com/video" />)
+
+    expect(screen.getByText('1080p 60fps · mp4')).toBeInTheDocument()
+
+    const downloadLink = screen.getByRole('link', { name: 'Download' })
+    expect(downloadLink.getAttribute('href')).toContain('/api/download?')
+    expect(downloadLink.getAttribute('href')).toContain('format_id=137')
+    expect(downloadLink.getAttribute('href')).toContain('source=https%3A%2F%2Fexample.com%2Fvideo')
+
+    expect(screen.queryByRole('link', { name: 'MP3' })).not.toBeInTheDocument()
+  })
+
+  it('shows streaming protocol labels and mp3 conversion for audio formats', () => {
+    const audioFormat: Format = {
+      format_id: '140',
+      ext: 'm4a',
+      is_audio_only: true,
+      audio_bitrate: 128,
+      filesize_pretty: '4 MB',
+      protocol: 'm3u8',
+      acodec: 'mp4a',
+      vcodec: 'none',
+    }
+
+    render(<FormatRow format={audioFormat} source="https://example.com/song" />)
+
+    expect(screen.getByText('HLS')).toBeInTheDocument()
+    const mp3Link = screen.getByRole('link', { name: /mp3/i })
+    expect(mp3Link.getAttribute('href')).toContain('/api/convert_mp3?')
+    expect(mp3Link.getAttribute('href')).toContain('source=https%3A%2F%2Fexample.com%2Fsong')
+  })
+
+  it('copies the proxy download url to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    render(<FormatRow format={baseFormat} source="https://example.com/video" />)
+
+    const copyButton = screen.getByRole('button', { name: /copy/i })
+    await userEvent.click(copyButton)
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+    expect(writeText.mock.calls[0][0]).toContain('/api/download?')
+    expect(writeText.mock.calls[0][0]).toContain('format_id=137')
+    expect(await screen.findByText('Copied!')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/App.utils.test.ts
+++ b/web/src/components/App.utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { formatDuration, normalizeInputUrl } from '../App'
+
+describe('App utility functions', () => {
+  describe('formatDuration', () => {
+    it('returns an em dash for missing or zero values', () => {
+      expect(formatDuration()).toBe('—')
+      expect(formatDuration(0)).toBe('—')
+    })
+
+    it('formats values under an hour with leading minutes', () => {
+      expect(formatDuration(59)).toBe('00:59')
+      expect(formatDuration(65)).toBe('01:05')
+    })
+
+    it('includes hours when needed', () => {
+      expect(formatDuration(3600)).toBe('1:00:00')
+      expect(formatDuration(3665)).toBe('1:01:05')
+    })
+  })
+
+  describe('normalizeInputUrl', () => {
+    it('preserves valid http(s) urls', () => {
+      expect(normalizeInputUrl('https://example.com/watch?v=123')).toBe('https://example.com/watch?v=123')
+      expect(normalizeInputUrl('http://example.com/track')).toBe('http://example.com/track')
+    })
+
+    it('adds https:// for bare domains', () => {
+      expect(normalizeInputUrl('example.com/video')).toBe('https://example.com/video')
+      expect(normalizeInputUrl('WWW.YOUTUBE.COM/watch?v=abc')).toBe('https://www.youtube.com/watch?v=abc')
+    })
+
+    it('returns null for unsupported protocols or invalid urls', () => {
+      expect(normalizeInputUrl('ftp://example.com/file')).toBeNull()
+      expect(normalizeInputUrl('not a url')).toBeNull()
+      expect(normalizeInputUrl('')).toBeNull()
+    })
+  })
+})

--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Button } from './Button'
+
+describe('Button component', () => {
+  it('renders a button element with default props', () => {
+    render(<Button>Click me</Button>)
+    const button = screen.getByRole('button', { name: 'Click me' })
+    expect(button.tagName).toBe('BUTTON')
+    expect(button).toHaveAttribute('type', 'button')
+    expect(button).toHaveClass('rounded-[var(--aoi-radii-control)]')
+  })
+
+  it('supports rendering as a different element', () => {
+    render(
+      <Button as="a" href="/docs" variant="surface">
+        Read docs
+      </Button>
+    )
+    const link = screen.getByRole('link', { name: 'Read docs' })
+    expect(link.tagName).toBe('A')
+    expect(link).not.toHaveAttribute('type')
+    expect(link).toHaveAttribute('href', '/docs')
+  })
+
+  it('applies variant, shape, fullWidth and iconOnly styles', () => {
+    render(
+      <Button
+        variant="primary"
+        shape="pill"
+        fullWidth
+        iconOnly
+        size="sm"
+        aria-label="Open menu"
+      >
+        <span aria-hidden="true">☰</span>
+      </Button>
+    )
+    const button = screen.getByRole('button', { name: 'Open menu' })
+    expect(button).toHaveClass('bg-[linear-gradient(110deg,_var(--aoi-brand-start),_var(--aoi-brand-mid),_var(--aoi-brand-end))]')
+    expect(button).toHaveClass('bg-[length:200%_200%]')
+    expect(button).toHaveClass('rounded-[var(--aoi-radii-pill)]')
+    expect(button).toHaveClass('w-full')
+    expect(button).toHaveClass('w-9')
+    expect(button).toHaveClass('gap-0')
+  })
+})

--- a/web/src/components/ui/ChipToggle.test.tsx
+++ b/web/src/components/ui/ChipToggle.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { ChipToggle } from './ChipToggle'
+
+describe('ChipToggle component', () => {
+  it('renders the provided label and optional icon', () => {
+    render(
+      <ChipToggle checked={false} onCheckedChange={() => {}} icon={<span data-testid="icon">★</span>}>
+        Option label
+      </ChipToggle>
+    )
+
+    expect(screen.getByText('Option label')).toBeInTheDocument()
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+    const checkbox = screen.getByRole('checkbox')
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it('toggles the checkbox and calls the change handler', async () => {
+    const onCheckedChange = vi.fn()
+    render(
+      <ChipToggle checked={false} onCheckedChange={onCheckedChange}>
+        Notify me
+      </ChipToggle>
+    )
+
+    const checkbox = screen.getByRole('checkbox')
+    await userEvent.click(checkbox)
+    expect(onCheckedChange).toHaveBeenCalledWith(true)
+  })
+
+  it('applies the checked styles when active', () => {
+    render(
+      <ChipToggle checked onCheckedChange={() => {}}>
+        Enabled option
+      </ChipToggle>
+    )
+
+    const text = screen.getByText('Enabled option')
+    const chip = text.parentElement
+    if (!chip) {
+      throw new Error('Chip container not found')
+    }
+    expect(chip).toHaveClass('shadow-inner')
+    expect(chip).toHaveClass('bg-[color:var(--aoi-colors-surface-strong)]')
+  })
+})


### PR DESCRIPTION
## Summary
- export reusable helpers from App for easier unit testing
- add Vitest coverage for FormatRow download rows and URL utilities
- cover Button and ChipToggle UI behaviors with Testing Library

## Testing
- `npm test -- --reporter verbose`


------
https://chatgpt.com/codex/tasks/task_e_68c9827f3b8c83289c8eaad9036cbcb7