### PR TITLE
Improve request cancellation and URL validation

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -436,6 +436,10 @@ async def extract_media(req: ExtractRequest):
     if not req.url:
         raise HTTPException(status_code=400, detail="Missing url")
 
+    parsed = urlparse(req.url)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise HTTPException(status_code=400, detail="Invalid source URL; must be http(s)")
+
     # First attempt with default options
     try:
         info = await _extract_info_threaded(req.url, build_ydl_opts(req.url))

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -162,6 +162,12 @@ def test_extract_returns_formats_and_subtitles(client: TestClient, mock_extract)
     assert any(s["lang"] == "en" for s in data.get("subtitles", []))
 
 
+def test_extract_rejects_invalid_scheme(client: TestClient):
+    r = client.post("/api/extract", json={"url": "file:///etc/passwd"})
+    assert r.status_code == 400
+    assert r.json()["detail"] == "Invalid source URL; must be http(s)"
+
+
 def test_proxy_download_streams_and_headers(monkeypatch, client: TestClient, mock_extract):
     import server.main as main
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -98,4 +98,30 @@ describe('App', () => {
     expect(screen.getByText(/download options/i)).toBeInTheDocument()
     expect(screen.getByText(/1080p/i)).toBeInTheDocument()
   })
+
+  it('continues rendering when localStorage.setItem throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('boom')
+      })
+
+    try {
+      expect(() => render(<App />)).not.toThrow()
+
+      await waitFor(() => {
+        expect(setItemSpy).toHaveBeenCalled()
+      })
+
+      expect(
+        await screen.findByRole('heading', {
+          name: /download from/i,
+        }),
+      ).toBeInTheDocument()
+    } finally {
+      setItemSpy.mockRestore()
+      warnSpy.mockRestore()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- wire the AbortController through media extraction fetches, clean up after completion, and swallow abort errors so cancellations are silent
- guard preference persistence against storage failures and cover the regression in a Vitest suite
- validate extract URLs on the backend and add a pytest to reject non-http(s) schemes

## Testing
- npm test
- npm test -- src/App.test.tsx
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cad76cc2d48328b8ff3564b03036bd