### PR TITLE
Fix mobile overflow from decorative gradients

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -278,7 +278,7 @@ export default function App() {
       <div className="absolute inset-0 bg-gradient-to-b from-slate-950 via-slate-950 to-slate-900" />
       <div className="absolute inset-0 bg-grid opacity-[0.30]" />
       <div className="absolute inset-0 bg-noise opacity-[0.06]" />
-      <div className="pointer-events-none absolute -top-40 left-1/2 -translate-x-1/2 h-80 w-[40rem] rounded-full blur-3xl bg-gradient-to-r from-fuchsia-500/20 via-purple-500/20 to-cyan-400/20" />
+      <div className="pointer-events-none absolute -top-40 left-1/2 -translate-x-1/2 h-64 sm:h-80 w-[40rem] max-w-[calc(100vw-2rem)] rounded-full blur-3xl bg-gradient-to-r from-fuchsia-500/20 via-purple-500/20 to-cyan-400/20" />
 
       <header className="relative z-10 sticky top-0 backdrop-blur border-b border-[color:var(--aoi-colors-border-subtle)] bg-[color:var(--aoi-colors-background)]/85 pt-[env(safe-area-inset-top)]">
         <div className="max-w-screen-content mx-auto px-4 py-3 flex flex-wrap items-center justify-between gap-2">

--- a/web/src/components/AuthModal.tsx
+++ b/web/src/components/AuthModal.tsx
@@ -154,8 +154,8 @@ export default function AuthModal({ open, onClose, onAuthSuccess }: Props) {
       <div className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
 
       {/* Decorative circles */}
-      <div className="pointer-events-none absolute -top-16 -left-10 h-48 w-48 rounded-full blur-3xl bg-gradient-to-br from-fuchsia-500/30 via-purple-500/30 to-cyan-400/30" aria-hidden="true" />
-      <div className="pointer-events-none absolute -bottom-16 -right-10 h-48 w-48 rounded-full blur-3xl bg-gradient-to-tr from-cyan-400/30 via-purple-500/30 to-fuchsia-500/30" aria-hidden="true" />
+      <div className="pointer-events-none absolute -top-16 left-0 sm:-left-10 h-40 w-40 sm:h-48 sm:w-48 rounded-full blur-3xl bg-gradient-to-br from-fuchsia-500/30 via-purple-500/30 to-cyan-400/30" aria-hidden="true" />
+      <div className="pointer-events-none absolute -bottom-16 right-0 sm:-right-10 h-40 w-40 sm:h-48 sm:w-48 rounded-full blur-3xl bg-gradient-to-tr from-cyan-400/30 via-purple-500/30 to-fuchsia-500/30" aria-hidden="true" />
 
       <div
         ref={contentRef}


### PR DESCRIPTION
## Summary
- constrain the hero background glow so it shrinks on narrow screens
- reposition and resize auth modal accent glows to keep them within the viewport

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cadc80e29c8328b5dd00bcd3b9caa2